### PR TITLE
クレジットカード登録画面の装飾

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,22 +3,22 @@ class CardsController < ApplicationController
   end
 
   def create
-    Payjp.api_key = ENV["PAYJP_SECRET_KEY"] # 環境変数を読み込む
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"] 
     customer = Payjp::Customer.create(
-    description: 'test', # テストカードであることを説明
-    card: params[:card_token] # 登録しようとしているカード情報
+    description: 'test', 
+    card: params[:card_token] 
     )
 
-    card = Card.new( # トークン化されたカード情報を保存する
-      card_token: params[:card_token], # カードトークン
-      customer_token: customer.id, # 顧客トークン
-      user_id: current_user.id # ログインしているユーザー
+    card = Card.new( 
+      card_token: params[:card_token], 
+      customer_token: customer.id, 
+      user_id: current_user.id 
     )
 
     if card.save
       redirect_to user_path(current_user.id)
     else
-      redirect_to "new" # カード登録画面
+      redirect_to :new
     end
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,6 @@
 class HomesController < ApplicationController
   def index
-    @celebs = Celeb.all.order("created_at DESC").page(params[:page])
+    @celebs = Celeb.all.order("created_at DESC").page(params[:page]).per(24)
   end
 
   def new_guest

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,24 +1,24 @@
 const pay = () => {
-  Payjp.setPublicKey(process.env.PAYJP_PUBLIC_KEY); // 環境変数を読み込む
+  Payjp.setPublicKey(process.env.PAYJP_PUBLIC_KEY); 
   const form = document.getElementById("charge-form"); 
-  form.addEventListener("submit", (e) => { // イベント発火
+  form.addEventListener("submit", (e) => { 
     e.preventDefault();
 
   const formResult = document.getElementById("charge-form");
   const formData = new FormData(formResult);
 
-  const card = { // カードオブジェクトを生成
-      number: formData.get("number"),              // カード番号
-      cvc: formData.get("cvc"),                    // カード裏面の3桁の数字
-      exp_month: formData.get("exp_month"),        // 有効期限の月
-      exp_year: `20${formData.get("exp_year")}`,   // 有効期限の年
+  const card = { 
+      number: formData.get("number"),     
+      cvc: formData.get("cvc"),           
+      exp_month: formData.get("exp_month"),        
+      exp_year: `20${formData.get("exp_year")}`,   
     };
     Payjp.createToken(card, (status, response) => {
       if (status === 200) {
         const token = response.id;
-        const renderDom = document.getElementById("charge-form");   //idを元に要素を取得
-        const tokenObj = `<input value=${token} name='card_token' type="hidden">`;   //paramsの中にトークンを含める
-        renderDom.insertAdjacentHTML("beforeend", tokenObj);  //フォームの一番最後に要素を追加
+        const renderDom = document.getElementById("charge-form");  
+        const tokenObj = `<input value=${token} name='card_token' type="hidden">`;   
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);  
 
         document.getElementById("number").removeAttribute("name");
         document.getElementById("cvc").removeAttribute("name");
@@ -26,8 +26,13 @@ const pay = () => {
         document.getElementById("exp_year").removeAttribute("name");
 
         document.getElementById("charge-form").submit();
-      }   
+      }
+      else{
+        location.href="/cards/new";
+        alert("登録に失敗しました");
+      }
     });
   });
+  
 };
 document.addEventListener("turbolinks:load", pay)

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,4 +1,3 @@
 class Card < ApplicationRecord
   belongs_to :user
-  
 end

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -1,18 +1,31 @@
-<%= form_with  url: cards_path, id: 'charge-form', class: 'card-form',local: true do |f| %>
-  <div class="Cardpage">
-    <h1>カード登録</h1>
-  </div><br>
-  <div class='form-wrap'>
-    <%= f.label :number, "【カード番号】" %>
+<%= render "shared/second-header" %>
+
+<%= form_with  url: cards_path, id: 'charge-form',  class: 'registration-main',local: true do |f| %>
+<div class='form-wrap'>
+  <div class="form-header">
+    <h1 class='form-header-text'>
+    カード登録
+    </h1>
+  </div>
+  <div class='form-group'>
+    <div class='form-text-wrap'>
+      <label class="form-text">【カード番号】</label>
+      <span class="indispensable">必須</span>
+    </div>
     <%= f.text_field :number, class:"number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
   </div>
-  <div class='form-wrap'>
-    <%= f.label :cvc ,"【ＣＶＣ】" %>
+  <div class='form-group'>
+    <div class='form-text-wrap'>
+      <label class="form-text">【ＣＶＣ】</label>
+      <span class="indispensable">必須</span>
+    </div>
     <%= f.text_field :cvc, class:"cvc", placeholder:"カード背面にある3桁の番号", maxlength:"4" %>
   </div>
-  <div class='form-wrap'>
-  <br>
-    <p>【有効期限】</p>
+  <div class='form-group'>
+    <div class='form-text-wrap'>
+      <label class="form-text">【有効期限】</label>
+      <span class="indispensable">必須</span>
+    </div>
     <div class='input-expiration-date-wrap'>
       <%= f.select :exp_month, 1..12, {include_blank: "---"}, class: "exp_month" %>
       <p>月</p>
@@ -20,5 +33,10 @@
       <p>年</p>
     </div>
   </div>
-  <%= f.submit "登録する" , class:"button" %>
+  <div class='register-btn'>
+    <%= f.submit "登録する" ,class:"register-red-btn", id:"card_register" %>
+  </div>
+</div>
 <% end %>
+
+<%= render "shared/second-footer" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -65,7 +65,7 @@
       <ul class='user-comment-list'>
         <li class='user-comment'>
           <%= image_tag like.room.celeb.image, class: 'img1'%>
-          <%= link_to "#{like.room.celeb.name}さんとのトーク", room_path(like.room), class: 'chat-room-name' %>
+          <%= link_to "#{like.room.celeb.name}さん", room_path(like.room), class: 'chat-room-name' %>
         </li>
       </ul>
     <% end %>


### PR DESCRIPTION
#What
クレジットカード登録画面の装飾

#Why
クレジットカード登録画面の見栄えをよくする
登録に失敗した際に登録画面に再度戻る。その際にsubmitボタンからdisabledを取り除き、送信ボタンを押せるようにする