### PR TITLE
Action cableの修正

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,18 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+    def find_verified_user
+      if current_user = User.find_by(id: cookies.encrypted[:user_id])
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
+  end
+end

--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -6,4 +6,5 @@ class MessageChannel < ApplicationCable::Channel
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
+
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,34 +7,20 @@ class MessagesController < ApplicationController
     @room = Room.find(params[:room_id])
     if current_user
       @message = Message.new(user_comment_params)
-      respond_to do |format| 
         if @message.save
           ActionCable.server.broadcast 'message_channel', content: @message
-          format.html { redirect_to room_path(@room) } 
-          format.json { render template: "rooms/show", status: :created, location: @room } 
-          format.js 
         else
           message_render_set
           @prices = Price.all
           @celebs_max = Celeb.all
-          format.html { render template: "rooms/show"} 
-          format.json { render json: @message.errors, status: :unprocessable_entity } 
         end
-      end
     else
       @message = Message.new(celeb_comment_params)
-      # respond_to do |format| 
         if @message.save
           ActionCable.server.broadcast 'message_channel', content: @message
-          # format.html { redirect_to room_path(@room) } 
-          # format.json { render template: "rooms/show", status: :created, location: @message } 
-          # format.js 
         else
           message_render_set
-          format.html { render template: "rooms/show" } 
-          format.json { render json: @message.errors, status: :unprocessable_entity } 
         end
-      # end
     end
   end
 

--- a/app/javascript/channels/message_channel.js
+++ b/app/javascript/channels/message_channel.js
@@ -1,5 +1,7 @@
 import consumer from "./consumer"
 
+
+
 consumer.subscriptions.create("MessageChannel", {
   connected() {
     // Called when the subscription is ready for use on the server

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,5 @@ class User < ApplicationRecord
   has_many :messages, dependent: :destroy
   has_one :card, dependent: :destroy
   has_many :likes, dependent: :destroy
+
 end


### PR DESCRIPTION
#What
Action cableの修正

#Why
うまく修正できなかった。
formatを用いても用いなくても相手に対して非同期でメッセージを送ることができるが、current_userを導入できないため、メッセージを振り分けられずエラーが出る